### PR TITLE
git: allow fetch any sha

### DIFF
--- a/options.go
+++ b/options.go
@@ -139,6 +139,8 @@ type FetchOptions struct {
 	// Name of the remote to fetch from. Defaults to origin.
 	RemoteName string
 	RefSpecs   []config.RefSpec
+	// Hashes that should be fetched explicitly
+	Hashes []plumbing.Hash
 	// Depth limit fetching to the specified number of commits from the tip of
 	// each remote branch history.
 	Depth int

--- a/remote.go
+++ b/remote.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"gopkg.in/src-d/go-billy.v4/osfs"
+
 	"github.com/goabstract/go-git/config"
 	"github.com/goabstract/go-git/plumbing"
 	"github.com/goabstract/go-git/plumbing/cache"
@@ -282,7 +283,7 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 		return nil, err
 	}
 
-	if len(o.RefSpecs) == 0 {
+	if len(o.RefSpecs) == 0 && len(o.Hashes) == 0 {
 		o.RefSpecs = r.c.Fetch
 	}
 
@@ -318,7 +319,17 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 		return nil, err
 	}
 
-	req.Wants, err = getWants(r.s, refs)
+	wantRefs, err := getWants(r.s, refs)
+	if err != nil {
+		return nil, err
+	}
+
+	var wants []plumbing.Hash
+	wants = append(wants, o.Hashes...)
+	wants = append(wants, wantRefs...)
+
+	req.Wants = wants
+
 	if len(req.Wants) > 0 {
 		req.Haves, err = getHaves(localRefs, remoteRefs, r.s)
 		if err != nil {

--- a/remote.go
+++ b/remote.go
@@ -324,11 +324,9 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 		return nil, err
 	}
 
-	var wants []plumbing.Hash
-	wants = append(wants, o.Hashes...)
-	wants = append(wants, wantRefs...)
-
-	req.Wants = wants
+	req.Wants = make([]plumbing.Hash, 0)
+	req.Wants = append(req.Wants, o.Hashes...)
+	req.Wants = append(req.Wants, wantRefs...)
 
 	if len(req.Wants) > 0 {
 		req.Haves, err = getHaves(localRefs, remoteRefs, r.s)

--- a/remote_test.go
+++ b/remote_test.go
@@ -204,7 +204,7 @@ func (s *RemoteSuite) TestFetchWithHashes(c *C) {
 	}, nil)
 
 	commits := r.s.(*memory.Storage).Commits
-	c.Assert(len(commits), Equals, 1)
+	c.Assert(commits, HasLen, 1)
 }
 
 func (s *RemoteSuite) TestFetchWithHashesDepthOfTwo(c *C) {
@@ -302,7 +302,7 @@ func (s *RemoteSuite) testFetch(c *C, r *Remote, o *FetchOptions, expected []*pl
 
 		// Only the depth-most parent of any given commit will be shallow.
 		commits := len(r.s.(*memory.Storage).Commits) / o.Depth
-		c.Assert(len(shallowCommits), Equals, commits)
+		c.Assert(shallowCommits, HasLen, commits)
 	} else {
 		c.Assert(refs, Equals, len(expected))
 	}
@@ -954,7 +954,7 @@ func (s *RemoteSuite) TestUpdateShallows(c *C) {
 
 	shallows, err := remote.s.Shallow()
 	c.Assert(err, IsNil)
-	c.Assert(len(shallows), Equals, 0)
+	c.Assert(shallows, HasLen, 0)
 
 	resp := new(packp.UploadPackResponse)
 	o := &FetchOptions{


### PR DESCRIPTION
Git has a server config to allow specific fetching behavior for any SHA:

```sh
git -C "$server" config uploadpack.allowAnySHA1InWant 1
```

Through the cli, a specific SHA can be used with the fetch command:

```sh
git fetch origin 6ecf0ef2c2dffb796033e5a02219af86ec6584e5
```

It also works with shallow commits by using a `--depth=1` option for the fetch command.

Refspecs may also be included in the same fetch command:

```sh
git fetch origin 6ecf0ef2c2dffb796033e5a02219af86ec6584e5 +refs/heads/branch:refs/remotes/origin/branch --depth=1
```