### PR TITLE
feat(fetch): allow fetching older commits in shallow repo

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -333,6 +333,7 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 		// we want those commits no matter what. By default the server
 		// wont return commit that are older than what we have in the
 		// HAVE list.
+		// TODO(melvin): This needs to be replaced by `shallow <sha>`
 		if o.Depth == 0 && len(o.Hashes) == 0 {
 			req.Haves, err = getHaves(localRefs, remoteRefs, r.s)
 			if err != nil {

--- a/remote.go
+++ b/remote.go
@@ -329,9 +329,15 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 	req.Wants = append(req.Wants, wantRefs...)
 
 	if len(req.Wants) > 0 {
-		req.Haves, err = getHaves(localRefs, remoteRefs, r.s)
-		if err != nil {
-			return nil, err
+		// if a depth or a list of hash is provided, we assume
+		// we want those commits no matter what. By default the server
+		// wont return commit that are older than what we have in the
+		// HAVE list.
+		if o.Depth == 0 && len(o.Hashes) == 0 {
+			req.Haves, err = getHaves(localRefs, remoteRefs, r.s)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		if err = r.fetchPack(ctx, o, s, req); err != nil {


### PR DESCRIPTION
This PR makes it possible to fetch old commits in a shallow repository.

The idea is that if we have a depth or a list of specific objects being provided to fetch, then we assume we skip the list HAVEs, allowing the server to send us potentially old commits.

This PR should unblock a bunch of internal work for us. The next step is to add support for `shallow <sha>`, `depeen <sha>`, etc. to go-git. 