### PR TITLE
refactor(fetch): properly report shallow commits

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -329,16 +329,14 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 	req.Wants = append(req.Wants, wantRefs...)
 
 	if len(req.Wants) > 0 {
-		// if a depth or a list of hash is provided, we assume
-		// we want those commits no matter what. By default the server
-		// wont return commit that are older than what we have in the
-		// HAVE list.
-		// TODO(melvin): This needs to be replaced by `shallow <sha>`
-		if o.Depth == 0 && len(o.Hashes) == 0 {
-			req.Haves, err = getHaves(localRefs, remoteRefs, r.s)
-			if err != nil {
-				return nil, err
-			}
+		req.Haves, err = getHaves(localRefs, remoteRefs, r.s)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Shallows, err = r.s.Shallow()
+		if err != nil {
+			return nil, err
 		}
 
 		if err = r.fetchPack(ctx, o, s, req); err != nil {


### PR DESCRIPTION
This PR removes our [previous patch](https://github.com/goabstract/go-git/pull/7), and replaces it by a proper solution (sending `shallow <sha>` to the server).

Fortunately, everything was actually already in place. The only part that was missing was setting the `Shallows` attribute of the upload-pack request. 

This repo's automated tests still pass, and our automated tests in our private projects still pass too (as well as manual tests I did).

If you want to test this PR with another repo you can pull this branch locally and update this other repo's `go.mod` to add:

```
replace github.com/goabstract/go-git => /Users/yourname/path/to/go-git
```