### PR TITLE
feat(repack): optimizes repack to prefetch data

### DIFF
--- a/plumbing/format/packfile/delta_breaker.go
+++ b/plumbing/format/packfile/delta_breaker.go
@@ -1,0 +1,60 @@
+package packfile
+
+import (
+	"github.com/goabstract/go-git/plumbing"
+)
+
+type DeltaBuilder struct {
+	dw   *deltaSelector
+	objs map[plumbing.Hash]*ObjectToPack
+}
+
+func NewDeltaBuilder(dw *deltaSelector, objs map[plumbing.Hash]*ObjectToPack) *DeltaBuilder {
+	return &DeltaBuilder{
+		dw:   dw,
+		objs: objs,
+	}
+}
+
+func (d *DeltaBuilder) PrepareData() (map[plumbing.Hash]*ObjectToPack, error) {
+	for _, obj := range d.objs {
+		if err := d.dw.restoreOriginal(obj); err != nil {
+			return nil, err
+		}
+
+		if err := d.breakChain(obj); err != nil {
+			return nil, err
+		}
+	}
+
+	return d.objs, nil
+}
+
+func (d *DeltaBuilder) breakChain(otp *ObjectToPack) error {
+	if !otp.Object.Type().IsDelta() {
+		return nil
+	}
+
+	// Initial ObjectToPack instances might have a delta assigned to Object
+	// but no actual base initially. Once Base is assigned to a delta, it means
+	// we already fixed it.
+	if otp.Base != nil {
+		return nil
+	}
+
+	do, ok := otp.Object.(plumbing.DeltaObject)
+	if !ok {
+		// if this is not a DeltaObject, then we cannot retrieve its base,
+		// so we have to break the delta chain here.
+		return d.dw.undeltify(otp)
+	}
+
+	base, ok := d.objs[do.BaseHash()]
+	if !ok {
+		// The base of the delta is not in our list of objects to pack, so
+		// we break the chain.
+		return d.dw.undeltify(otp)
+	}
+	otp.SetDelta(base, otp.Object)
+	return nil
+}


### PR DESCRIPTION
This PR addresses the memory leak that occurs when repacking a repo. Go-Git takes the approach of load it as you need it which is great at small scale repos but when you have a larger repo it causes memory to spike.
![Screen Shot 2020-02-18 at 10 20 27 AM](https://user-images.githubusercontent.com/700344/74975727-c3274100-53e4-11ea-8048-d82174a33df9.png)

This fix addresses this and lowers the memory issue as shown below by loading all the  relative commits first and use them in memory rather than running to disk each time.

![Screen Shot 2020-02-20 at 12 56 42 PM](https://user-images.githubusercontent.com/700344/74975852-f4a00c80-53e4-11ea-8f86-32f5df96f5e8.png)

