### PR TITLE
fix: progress data race

### DIFF
--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/goabstract/go-git/v5/plumbing"
+	"github.com/goabstract/go-git/v5/plumbing/progress"
 	"github.com/goabstract/go-git/v5/storage"
 	"github.com/goabstract/go-git/v5/utils/ioutil"
 
@@ -193,9 +194,9 @@ func (d *DotGit) Shallow() (billy.File, error) {
 
 // NewObjectPack return a writer for a new packfile, it saves the packfile to
 // disk and also generates and save the index for the given packfile.
-func (d *DotGit) NewObjectPack() (*PackWriter, error) {
+func (d *DotGit) NewObjectPack(pc *progress.Collector) (*PackWriter, error) {
 	d.cleanPackList()
-	return newPackWrite(d.fs)
+	return newPackWrite(d.fs, pc)
 }
 
 // ObjectPacks returns the list of availables packfiles

--- a/storage/filesystem/dotgit/writers_test.go
+++ b/storage/filesystem/dotgit/writers_test.go
@@ -30,7 +30,7 @@ func (s *SuiteDotGit) TestNewObjectPack(c *C) {
 	fs := osfs.New(dir)
 	dot := New(fs)
 
-	w, err := dot.NewObjectPack()
+	w, err := dot.NewObjectPack(nil)
 	c.Assert(err, IsNil)
 
 	_, err = io.Copy(w, f.Packfile())
@@ -75,7 +75,7 @@ func (s *SuiteDotGit) TestNewObjectPackUnused(c *C) {
 	fs := osfs.New(dir)
 	dot := New(fs)
 
-	w, err := dot.NewObjectPack()
+	w, err := dot.NewObjectPack(nil)
 	c.Assert(err, IsNil)
 
 	c.Assert(w.Close(), IsNil)
@@ -146,7 +146,7 @@ func (s *SuiteDotGit) TestPackWriterUnusedNotify(c *C) {
 
 	fs := osfs.New(dir)
 
-	w, err := newPackWrite(fs)
+	w, err := newPackWrite(fs, nil)
 	c.Assert(err, IsNil)
 
 	w.Notify = func(h plumbing.Hash, idx *idxfile.Writer) {

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -99,12 +99,10 @@ func (s *ObjectStorage) packfileWriter(pc *progress.Collector) (io.WriteCloser, 
 		return nil, err
 	}
 
-	w, err := s.dir.NewObjectPack()
+	w, err := s.dir.NewObjectPack(pc)
 	if err != nil {
 		return nil, err
 	}
-
-	w.ProgressCollector = pc
 
 	w.Notify = func(h plumbing.Hash, writer *idxfile.Writer) {
 		index, err := writer.Index()


### PR DESCRIPTION
When I originally worked on this, I had utterly forgotten to build with `-race`. 🤦‍♂ 

Packfile writers are created and the index gets built in a separate goroutine. A data race occurred when setting up the progress collector. I plumbed the progress collector into the `newPackWrite`
function outright. That way, the call to `buildIndex` could take it. Furthermore, using a mutex to serialize reporting for receiving objects and resolving deltas.