### PR TITLE
feat: enable shallow when advertised by server

### DIFF
--- a/plumbing/protocol/packp/ulreq.go
+++ b/plumbing/protocol/packp/ulreq.go
@@ -98,6 +98,10 @@ func NewUploadRequestFromCapabilities(adv *capability.List) *UploadRequest {
 		r.Capabilities.Set(capability.Agent, capability.DefaultAgent)
 	}
 
+	if adv.Supports(capability.Shallow) {
+		r.Capabilities.Set(capability.Shallow)
+	}
+
 	return r
 }
 

--- a/plumbing/protocol/packp/ulreq_test.go
+++ b/plumbing/protocol/packp/ulreq_test.go
@@ -26,10 +26,11 @@ func (s *UlReqSuite) TestNewUploadRequestFromCapabilities(c *C) {
 	cap.Set(capability.ThinPack)
 	cap.Set(capability.OFSDelta)
 	cap.Set(capability.Agent, "foo")
+	cap.Set(capability.Shallow)
 
 	r := NewUploadRequestFromCapabilities(cap)
 	c.Assert(r.Capabilities.String(), Equals,
-		"multi_ack_detailed side-band-64k thin-pack ofs-delta agent=go-git/4.x",
+		"multi_ack_detailed side-band-64k thin-pack ofs-delta agent=go-git/4.x shallow",
 	)
 }
 


### PR DESCRIPTION
Capabilities are individually selected based on what the server advertises. This PR enables upload requests to use the `shallow` capability.