### PR TITLE
fix: correctly deepen shallows

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -777,7 +777,7 @@ func getWants(localStorer storage.Storer, refs memory.ReferenceStorage) ([]plumb
 		}
 
 		if exists {
-			if isShallow, ok := shallowCommits[hash]; ok && isShallow {
+			if _, isShallow := shallowCommits[hash]; isShallow {
 				wants[hash] = true
 			}
 		} else {

--- a/remote.go
+++ b/remote.go
@@ -1135,20 +1135,13 @@ func (r *Remote) updateShallow(o *FetchOptions, resp *packp.UploadPackResponse) 
 
 	shallows := []plumbing.Hash{}
 
-	// filter out the SHAs that are unshallowed
-	for _, s := range currentShallows {
-		if isShallow, ok := shallowUpdates[s]; ok && !isShallow {
-			continue
-		}
-		shallowUpdates[s] = true
-		shallows = append(shallows, s)
-	}
-
-	// filter out the SHAs that are already shallow
-	for _, s := range resp.Shallows {
+	// filter out the SHAs that are unshallowed, and only include each
+	// shallow commit once
+	for _, s := range append(currentShallows, resp.Shallows...) {
 		if _, ok := shallowUpdates[s]; ok {
 			continue
 		}
+		shallowUpdates[s] = true
 		shallows = append(shallows, s)
 	}
 

--- a/remote.go
+++ b/remote.go
@@ -1145,7 +1145,7 @@ func (r *Remote) pruneShallow() error {
 }
 
 func (r *Remote) updateShallow(o *FetchOptions, resp *packp.UploadPackResponse) error {
-	if o.Depth == 0 {
+	if o.Depth == 0 || len(resp.Shallows) == 0 {
 		return nil
 	}
 
@@ -1154,17 +1154,14 @@ func (r *Remote) updateShallow(o *FetchOptions, resp *packp.UploadPackResponse) 
 		return err
 	}
 
-	if len(resp.Shallows) > 0 {
-	outer:
-		for _, s := range resp.Shallows {
-			for _, oldS := range shallows {
-				if s == oldS {
-					continue outer
-				}
+outer:
+	for _, s := range resp.Shallows {
+		for _, oldS := range shallows {
+			if s == oldS {
+				continue outer
 			}
-			shallows = append(shallows, s)
 		}
-
+		shallows = append(shallows, s)
 	}
 
 	return r.s.SetShallow(shallows)

--- a/remote_test.go
+++ b/remote_test.go
@@ -207,10 +207,8 @@ func (s *RemoteSuite) TestFetchWithHashes(c *C) {
 		Hashes: []plumbing.Hash{
 			plumbing.NewHash(hash),
 		},
-	}, []*plumbing.Reference{
-		// we get this reference because the tag points to it
-		plumbing.NewReferenceFromStrings("refs/tags/v1.0.0", hash),
-	})
+		Tags: NoTags,
+	}, nil)
 
 	commits := r.s.(*memory.Storage).Commits
 	c.Assert(commits, HasLen, 1)
@@ -239,9 +237,8 @@ func (s *RemoteSuite) TestFetchWithHashesInShallow(c *C) {
 		Hashes: []plumbing.Hash{
 			headHash,
 		},
-	}, []*plumbing.Reference{
-		plumbing.NewReferenceFromStrings("refs/tags/v1.0.0", headHash.String()),
-	})
+		Tags: NoTags,
+	}, nil)
 
 	s.assertShallows(c, r, 1)
 
@@ -260,9 +257,9 @@ func (s *RemoteSuite) TestFetchWithHashesInShallow(c *C) {
 		Hashes: []plumbing.Hash{
 			olderHash,
 		},
+		Tags: NoTags,
 	}, []*plumbing.Reference{
 		plumbing.NewReferenceFromStrings("refs/remotes/origin/master", headHash.String()),
-		plumbing.NewReferenceFromStrings("refs/tags/v1.0.0", headHash.String()),
 	})
 
 	// Control we did get it
@@ -335,9 +332,8 @@ func (s *RemoteSuite) TestFetchWithHashesDepthOfTwo(c *C) {
 		Hashes: []plumbing.Hash{
 			plumbing.NewHash(hash),
 		},
-	}, []*plumbing.Reference{
-		plumbing.NewReferenceFromStrings("refs/tags/v1.0.0", hash),
-	})
+		Tags: NoTags,
+	}, nil)
 
 	commits := r.s.(*memory.Storage).Commits
 	c.Assert(commits, HasLen, 2)

--- a/remote_test.go
+++ b/remote_test.go
@@ -251,16 +251,11 @@ func (s *RemoteSuite) TestFetchWithHashesInShallow(c *C) {
 	// We now fetch an older SHA
 	s.testFetch(c, r, &FetchOptions{
 		Depth: 1,
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("+refs/heads/master:refs/remotes/origin/master"),
-		},
 		Hashes: []plumbing.Hash{
 			olderHash,
 		},
 		Tags: NoTags,
-	}, []*plumbing.Reference{
-		plumbing.NewReferenceFromStrings("refs/remotes/origin/master", headHash.String()),
-	})
+	}, nil)
 
 	// Control we did get it
 	commits = r.s.(*memory.Storage).Commits
@@ -268,7 +263,10 @@ func (s *RemoteSuite) TestFetchWithHashesInShallow(c *C) {
 	_, err = object.GetCommit(r.s, olderHash)
 	c.Assert(err, IsNil)
 
-	s.assertShallows(c, r, 1)
+	// NOTE: the server doesn't emit an `unshallow` packet line in
+	// this scenario, so it won't know to update the list of shallow
+	// commits. This is consistent with git cli.
+	s.assertShallows(c, r, 2)
 }
 
 func (s *RemoteSuite) TestFetchShallowBranchHeadThenFetchUnshallowBranch(c *C) {

--- a/remote_test.go
+++ b/remote_test.go
@@ -190,6 +190,8 @@ func (s *RemoteSuite) TestFetchWithDepth(c *C) {
 		plumbing.NewReferenceFromStrings("refs/tags/v1.0.0", "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
 	})
 
+	s.assertShallows(c, r, 2)
+
 	c.Assert(r.s.(*memory.Storage).Objects, HasLen, 18)
 }
 
@@ -198,15 +200,22 @@ func (s *RemoteSuite) TestFetchWithHashes(c *C) {
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 
+	hash := "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"
+
 	s.testFetch(c, r, &FetchOptions{
 		Depth: 1,
 		Hashes: []plumbing.Hash{
-			plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
+			plumbing.NewHash(hash),
 		},
-	}, nil)
+	}, []*plumbing.Reference{
+		// we get this reference because the tag points to it
+		plumbing.NewReferenceFromStrings("refs/tags/v1.0.0", hash),
+	})
 
 	commits := r.s.(*memory.Storage).Commits
 	c.Assert(commits, HasLen, 1)
+
+	s.assertShallows(c, r, 1)
 }
 
 func (s *RemoteSuite) TestFetchWithHashesInShallow(c *C) {
@@ -230,7 +239,11 @@ func (s *RemoteSuite) TestFetchWithHashesInShallow(c *C) {
 		Hashes: []plumbing.Hash{
 			headHash,
 		},
-	}, nil)
+	}, []*plumbing.Reference{
+		plumbing.NewReferenceFromStrings("refs/tags/v1.0.0", headHash.String()),
+	})
+
+	s.assertShallows(c, r, 1)
 
 	// Control we did get it
 	commits := r.s.(*memory.Storage).Commits
@@ -247,13 +260,67 @@ func (s *RemoteSuite) TestFetchWithHashesInShallow(c *C) {
 		Hashes: []plumbing.Hash{
 			olderHash,
 		},
-	}, nil)
+	}, []*plumbing.Reference{
+		plumbing.NewReferenceFromStrings("refs/remotes/origin/master", headHash.String()),
+		plumbing.NewReferenceFromStrings("refs/tags/v1.0.0", headHash.String()),
+	})
 
 	// Control we did get it
 	commits = r.s.(*memory.Storage).Commits
 	c.Assert(commits, HasLen, 2)
 	_, err = object.GetCommit(r.s, olderHash)
 	c.Assert(err, IsNil)
+
+	s.assertShallows(c, r, 1)
+}
+
+func (s *RemoteSuite) TestFetchShallowBranchHeadThenFetchUnshallowBranch(c *C) {
+	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+		URLs: []string{s.GetBasicLocalRepositoryURL()},
+	})
+
+	// We first need to set the right capabilities otherwise we can't fetch
+	// the commit we want
+	p := filepath.Join(r.c.URLs[0], "config")
+	cfgCmd := exec.Command("git", "config", "--file", p, "--bool", "uploadpack.allowAnySHA1InWant", "true")
+	err := cfgCmd.Run()
+	c.Assert(err, IsNil)
+
+	headHash := plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881")
+	firstHash := plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d")
+
+	// We start by fetching the HEAD
+	s.testFetch(c, r, &FetchOptions{
+		Depth: 1,
+		Hashes: []plumbing.Hash{
+			headHash,
+		},
+	}, nil)
+
+	// Control we did get it
+	commits := r.s.(*memory.Storage).Commits
+	c.Assert(commits, HasLen, 1)
+	_, err = object.GetCommit(r.s, headHash)
+	c.Assert(err, IsNil)
+
+	// Fetch the branch where our shallow commit is the head of the branch
+	s.testFetch(c, r, &FetchOptions{
+		Depth: 2147483647,
+		RefSpecs: []config.RefSpec{
+			config.RefSpec("+refs/heads/branch:refs/remotes/origin/branch"),
+		},
+	}, []*plumbing.Reference{
+		plumbing.NewReferenceFromStrings("refs/remotes/origin/branch", headHash.String()),
+	})
+
+	// Control we did get it
+	commits = r.s.(*memory.Storage).Commits
+	totalCommitsInBranch := 8 // SEE: https://github.com/git-fixtures/basic/commits/branch
+	c.Assert(len(commits), Equals, totalCommitsInBranch)
+	_, err = object.GetCommit(r.s, firstHash)
+	c.Assert(err, IsNil)
+
+	s.assertShallows(c, r, 0)
 }
 
 func (s *RemoteSuite) TestFetchWithHashesDepthOfTwo(c *C) {
@@ -261,19 +328,21 @@ func (s *RemoteSuite) TestFetchWithHashesDepthOfTwo(c *C) {
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 
-	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+	hash := "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"
 
 	s.testFetch(c, r, &FetchOptions{
 		Depth: 2,
 		Hashes: []plumbing.Hash{
-			hash,
+			plumbing.NewHash(hash),
 		},
-	}, nil)
+	}, []*plumbing.Reference{
+		plumbing.NewReferenceFromStrings("refs/tags/v1.0.0", hash),
+	})
 
 	commits := r.s.(*memory.Storage).Commits
 	c.Assert(commits, HasLen, 2)
 
-	commit, err := object.GetCommit(r.s, hash)
+	commit, err := object.GetCommit(r.s, plumbing.NewHash(hash))
 	c.Assert(err, IsNil)
 
 	parents := commit.Parents()
@@ -291,6 +360,8 @@ func (s *RemoteSuite) TestFetchWithHashesDepthOfTwo(c *C) {
 
 	c.Assert(err, IsNil)
 	c.Assert(output, DeepEquals, expected)
+
+	s.assertShallows(c, r, 1)
 }
 
 func (s *RemoteSuite) TestFetchWithHashesAndReferences(c *C) {
@@ -334,27 +405,28 @@ func (s *RemoteSuite) TestFetchWithHashesButMissing(c *C) {
 	})
 
 	c.Assert(err.Error(), Equals, "empty packfile")
+	s.assertShallows(c, r, 0)
+}
+
+func (s *RemoteSuite) assertShallows(c *C, r *Remote, expected int) {
+	shallowCommits, err := r.s.Shallow()
+	c.Assert(err, IsNil)
+
+	c.Assert(shallowCommits, HasLen, expected)
 }
 
 func (s *RemoteSuite) testFetch(c *C, r *Remote, o *FetchOptions, expected []*plumbing.Reference) {
 	err := r.Fetch(o)
-	c.Assert(err, IsNil)
+	if err != NoErrAlreadyUpToDate {
+		c.Assert(err, IsNil)
+	}
 
 	var refs int
 	l, err := r.s.IterReferences()
 	c.Assert(err, IsNil)
 	l.ForEach(func(r *plumbing.Reference) error { refs++; return nil })
 
-	if o.Depth > 0 {
-		shallowCommits, err := r.s.Shallow()
-		c.Assert(err, IsNil)
-
-		// Only the depth-most parent of any given commit will be shallow.
-		commits := len(r.s.(*memory.Storage).Commits) / o.Depth
-		c.Assert(shallowCommits, HasLen, commits)
-	} else {
-		c.Assert(refs, Equals, len(expected))
-	}
+	c.Assert(refs, Equals, len(expected))
 
 	for _, exp := range expected {
 		r, err := r.s.Reference(exp.Name())

--- a/remote_test.go
+++ b/remote_test.go
@@ -200,12 +200,12 @@ func (s *RemoteSuite) TestFetchWithHashes(c *C) {
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 
-	hash := "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"
+	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
 
 	s.testFetch(c, r, &FetchOptions{
 		Depth: 1,
 		Hashes: []plumbing.Hash{
-			plumbing.NewHash(hash),
+			hash,
 		},
 		Tags: NoTags,
 	}, nil)
@@ -323,12 +323,12 @@ func (s *RemoteSuite) TestFetchWithHashesDepthOfTwo(c *C) {
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 
-	hash := "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"
+	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
 
 	s.testFetch(c, r, &FetchOptions{
 		Depth: 2,
 		Hashes: []plumbing.Hash{
-			plumbing.NewHash(hash),
+			hash,
 		},
 		Tags: NoTags,
 	}, nil)
@@ -336,7 +336,7 @@ func (s *RemoteSuite) TestFetchWithHashesDepthOfTwo(c *C) {
 	commits := r.s.(*memory.Storage).Commits
 	c.Assert(commits, HasLen, 2)
 
-	commit, err := object.GetCommit(r.s, plumbing.NewHash(hash))
+	commit, err := object.GetCommit(r.s, hash)
 	c.Assert(err, IsNil)
 
 	parents := commit.Parents()

--- a/remote_test.go
+++ b/remote_test.go
@@ -200,12 +200,10 @@ func (s *RemoteSuite) TestFetchWithHashes(c *C) {
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 
-	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
-
 	s.testFetch(c, r, &FetchOptions{
 		Depth: 1,
 		Hashes: []plumbing.Hash{
-			hash,
+			plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
 		},
 		Tags: NoTags,
 	}, nil)

--- a/repository_test.go
+++ b/repository_test.go
@@ -2822,7 +2822,7 @@ func (s *RepositorySuite) TestBrokenMultipleShallowFetch(c *C) {
 
 	shallows, err = r.Storer.Shallow()
 	c.Assert(err, IsNil)
-	c.Assert(len(shallows), Equals, 3)
+	c.Assert(len(shallows), Equals, 2)
 
 	ref, err = r.Reference("refs/heads/master", true)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
# What

Fetching with go-git was not sending `want` packet lines for shallow commits. In this specific scenario, the local repository had a shallow commit, and the server advertised a ref whose head is that same commit. Given that the commit existed locally, go-git would not send a `want` for that SHA.

This PR does two things (see 🍜 ):

### Advertised hashes are now cross referenced with the list of shallow commits.

Example of packets from the git protocol:

```
10:16:23.579135 pkt-line.c:80           packet:        fetch> command=fetch
10:16:23.579152 pkt-line.c:80           packet:        fetch> agent=git/2.26.2
10:16:23.579158 pkt-line.c:80           packet:        fetch> 0001
10:16:23.579163 pkt-line.c:80           packet:        fetch> thin-pack
10:16:23.579169 pkt-line.c:80           packet:        fetch> ofs-delta
10:16:23.579178 pkt-line.c:80           packet:        fetch> shallow e8d3ffab552895c19b9fcf7aa264d277cde33881
10:16:23.579186 pkt-line.c:80           packet:        fetch> deepen 2147483647
10:16:23.579193 pkt-line.c:80           packet:        fetch> want e8d3ffab552895c19b9fcf7aa264d277cde33881
10:16:23.579198 pkt-line.c:80           packet:        fetch> done
10:16:23.579203 pkt-line.c:80           packet:        fetch> 0000
```

In this scenario, go-git correctly encodes a `shallow` packet line, but doesn't actually include a `want` line since the commit already exists. This has been changed so that a `want` line will be included for an existing commit that is shallow.

It may be worth noting that `git fetch` takes an `--unshallow` flag, which results in the client sending a `deepen 2147483647` packet line.

### Shallow commits are now maintained after fetch operations.

Previously, go-git only ever appended to the list of shallow commits. This has been updated, and commits that are no longer shallow will be pruned immediately after processing a packfile response from the server. The approach is to simply iterate the list of shallows and determine whether their parent commits exist. Specifically, it requires that at least one parent commit exists locally (since a missing parent to a merge commit could be the head of an unfetched branch).

For what it's worth, I don't think this is the exact behavior that is expected. The server emits an `unshallow` packet line indicating to the client which of its shallow commits are no longer shallow. It may be ideal to manage the list of shallow commits for these individual cases, but this is beyond my knowledge of how git manages shallow commits.

```
10:16:23.623650 pkt-line.c:80           packet:        fetch< shallow-info
10:16:23.626559 pkt-line.c:80           packet:        fetch< unshallow e8d3ffab552895c19b9fcf7aa264d277cde33881
10:16:23.626584 pkt-line.c:80           packet:        fetch< 0001
10:16:23.626994 pkt-line.c:80           packet:        fetch< packfile
```

## Testing

Examples done using [git-fixtures/basic](https://github.com/git-fixtures/basic).

There is a test included in this PR that demonstrates the scenario described above. I compared behavior with git version 2.26.2, using the following commands:

```sh
mkdir basic && cd basic && git init
git remote add origin git@github.com:git-fixtures/basic
git fetch origin e8d3ffab552895c19b9fcf7aa264d277cde33881 --depth=1
cat .git/shallow
GIT_TRACE_PACKET=1 git fetch origin branch --unshallow
```

To run tests locally, pull the branch and run `make test`.