### PR TITLE
feat(prune): Only walk refs if there are loose objects.

### DIFF
--- a/prune.go
+++ b/prune.go
@@ -36,13 +36,18 @@ func (r *Repository) Prune(opt PruneOptions) error {
 		return ErrLooseObjectsNotSupported
 	}
 
-	pw := newObjectWalker(r.Storer)
-	err := pw.walkAllRefs()
-	if err != nil {
-		return err
-	}
+	var pw *objectWalker
+
 	// Now walk all (loose) objects in storage.
 	return los.ForEachObjectHash(func(hash plumbing.Hash) error {
+		if pw == nil {
+			pw = newObjectWalker(r.Storer)
+			err := pw.walkAllRefs()
+			if err != nil {
+				return err
+			}
+		}
+
 		// Get out if we have seen this object.
 		if pw.isSeen(hash) {
 			return nil


### PR DESCRIPTION
Part of: [PLATFORM-1848](https://goabstract.atlassian.net/browse/PLATFORM-1848)
Mentioned: https://github.com/goabstract/projects/pull/4985#discussion_r456519455

`Prune()` will walk all refs even if there are no loose objects to prune, which can be a huge waste of time. This PR defers ref walking until we iterate the first loose object - ensuring that we actually have something to prune and aren't wasting our time.